### PR TITLE
[Refactor]: Simplify agent method to just be called folder

### DIFF
--- a/src/Agents/Cline.php
+++ b/src/Agents/Cline.php
@@ -12,9 +12,9 @@ use Pair\Contracts\Agent;
 final class Cline implements Agent
 {
     /**
-     * Returns the base folder or file for the agent.
+     * Returns the base folder for the agent.
      */
-    public function baseFolderOrFile(): string
+    public function baseFolder(): string
     {
         return '.clinerules';
     }

--- a/src/Agents/Cursor.php
+++ b/src/Agents/Cursor.php
@@ -12,9 +12,9 @@ use Pair\Contracts\Agent;
 final class Cursor implements Agent
 {
     /**
-     * Returns the base folder or file for the agent.
+     * Returns the base folder for the agent.
      */
-    public function baseFolderOrFile(): string
+    public function baseFolder(): string
     {
         return '.cursor/rules';
     }

--- a/src/Agents/Junie.php
+++ b/src/Agents/Junie.php
@@ -12,9 +12,9 @@ use Pair\Contracts\Agent;
 final class Junie implements Agent
 {
     /**
-     * Returns the base folder or file for the agent.
+     * Returns the base folder for the agent.
      */
-    public function baseFolderOrFile(): string
+    public function baseFolder(): string
     {
         return '.junie';
     }

--- a/src/Agents/Windsurf.php
+++ b/src/Agents/Windsurf.php
@@ -12,9 +12,9 @@ use Pair\Contracts\Agent;
 final class Windsurf implements Agent
 {
     /**
-     * Returns the base folder or file for the agent.
+     * Returns the base folder for the agent.
      */
-    public function baseFolderOrFile(): string
+    public function baseFolder(): string
     {
         return '.windsurfrules';
     }

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -101,7 +101,7 @@ final class InstallCommand extends Command
         $gitignoreContent = file_get_contents($gitignorePath);
 
         foreach ((new AgentManager)->all() as $agent) {
-            $baseFolder = $agent->baseFolderOrFile();
+            $baseFolder = $agent->baseFolder();
 
             if (str_contains($gitignoreContent, $baseFolder)) {
                 continue;

--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -10,7 +10,7 @@ namespace Pair\Contracts;
 interface Agent
 {
     /**
-     * Returns the base folder or file for the agent.
+     * Returns the base folder for the agent.
      */
-    public function baseFolderOrFile(): string;
+    public function baseFolder(): string;
 }

--- a/src/Support/RulesGenerator.php
+++ b/src/Support/RulesGenerator.php
@@ -17,7 +17,7 @@ final readonly class RulesGenerator
     public static function generate(Agent $agent, string $path): void
     {
         Filesystem::remove(
-            $base = ($path.'/'.$agent->baseFolderOrFile()),
+            $base = ($path.'/'.$agent->baseFolder()),
         );
 
         mkdir($base, 0755, true);


### PR DESCRIPTION
As discovered during the stream, the contract only returns folders and not files.
Therefore we can rename the method to make this more clear!