### PR TITLE
feat: add kiro agent support

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -5,7 +5,8 @@
             "php",
             "junie",
             "filesystem",
-            "gitignore"
+            "gitignore",
+            "kiro"
         ],
         "paths": []
     }

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -7,6 +7,7 @@ namespace Pair;
 use Pair\Agents\Cline;
 use Pair\Agents\Cursor;
 use Pair\Agents\Junie;
+use Pair\Agents\Kiro;
 use Pair\Agents\Windsurf;
 use Pair\Contracts\Agent;
 
@@ -26,6 +27,7 @@ final readonly class AgentManager
             Windsurf::class,
             Junie::class,
             Cline::class,
+            Kiro::class,
         ]
     ) {
         //

--- a/src/Agents/Kiro.php
+++ b/src/Agents/Kiro.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pair\Agents;
+
+use Pair\Contracts\Agent;
+
+/**
+ * @internal
+ */
+final class Kiro implements Agent
+{
+    /**
+     * Returns the base folder for the agent.
+     */
+    public function baseFolder(): string
+    {
+        return '.kiro/steering';
+    }
+}


### PR DESCRIPTION
This PR introduces initial support for the `Kiro` agent. It includes specified directory rules to ensure proper structure and interaction within Kiro’s environment.

[Kiro](https://kiro.dev/about/) is a new agentic IDE from AWS, built to work alongside developers from prototype to production. It delivers a fast, AI-powered development experience, driven by a relentless focus on iteration and productivity.