### PR TITLE
feat: add GitHub Copilot integration

### DIFF
--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pair;
 
 use Pair\Agents\Cline;
+use Pair\Agents\Copilot;
 use Pair\Agents\Cursor;
 use Pair\Agents\Junie;
 use Pair\Agents\Windsurf;
@@ -26,6 +27,7 @@ final readonly class AgentManager
             Windsurf::class,
             Junie::class,
             Cline::class,
+            Copilot::class,
         ]
     ) {
         //

--- a/src/AgentManager.php
+++ b/src/AgentManager.php
@@ -45,4 +45,43 @@ final readonly class AgentManager
             $this->agents
         );
     }
+
+    /**
+     * Returns agents filtered by the given names.
+     *
+     * @param  array<int,string>  $agentNames
+     * @return array<int,Agent>
+     */
+    public function only(array $agentNames): array
+    {
+        if (empty($agentNames)) {
+            return $this->all();
+        }
+
+        $normalizedNames = array_map('strtolower', $agentNames);
+        $filteredAgents = [];
+
+        foreach ($this->agents as $agentClass) {
+            $agentName = strtolower(basename(str_replace('\\', '/', $agentClass)));
+
+            if (in_array($agentName, $normalizedNames, true)) {
+                $filteredAgents[] = new $agentClass;
+            }
+        }
+
+        return $filteredAgents;
+    }
+
+    /**
+     * Returns the available agent names.
+     *
+     * @return array<int,string>
+     */
+    public function getAvailableAgentNames(): array
+    {
+        return array_map(
+            static fn (string $agentClass): string => strtolower(basename(str_replace('\\', '/', $agentClass))),
+            $this->agents
+        );
+    }
 }

--- a/src/Agents/Cline.php
+++ b/src/Agents/Cline.php
@@ -18,4 +18,21 @@ final class Cline implements Agent
     {
         return '.clinerules';
     }
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string
+    {
+        return 'mdc';
+    }
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string
+    {
+        $basename = pathinfo($sourceFile, PATHINFO_FILENAME);
+        return $basename . '.' . $this->fileExtension();
+    }
 }

--- a/src/Agents/Copilot.php
+++ b/src/Agents/Copilot.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pair\Agents;
+
+use Pair\Contracts\Agent;
+
+/**
+ * @internal
+ */
+final class Copilot implements Agent
+{
+    /**
+     * Returns the base folder for the agent.
+     */
+    public function baseFolder(): string
+    {
+        return '.copilot';
+    }
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string
+    {
+        return 'md';
+    }
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string
+    {
+        $basename = pathinfo($sourceFile, PATHINFO_FILENAME);
+        return $basename . '.' . $this->fileExtension();
+    }
+}

--- a/src/Agents/Cursor.php
+++ b/src/Agents/Cursor.php
@@ -18,4 +18,21 @@ final class Cursor implements Agent
     {
         return '.cursor/rules';
     }
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string
+    {
+        return 'mdc';
+    }
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string
+    {
+        $basename = pathinfo($sourceFile, PATHINFO_FILENAME);
+        return $basename . '.' . $this->fileExtension();
+    }
 }

--- a/src/Agents/Junie.php
+++ b/src/Agents/Junie.php
@@ -18,4 +18,21 @@ final class Junie implements Agent
     {
         return '.junie';
     }
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string
+    {
+        return 'mdc';
+    }
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string
+    {
+        $basename = pathinfo($sourceFile, PATHINFO_FILENAME);
+        return $basename . '.' . $this->fileExtension();
+    }
 }

--- a/src/Agents/Windsurf.php
+++ b/src/Agents/Windsurf.php
@@ -18,4 +18,21 @@ final class Windsurf implements Agent
     {
         return '.windsurfrules';
     }
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string
+    {
+        return 'mdc';
+    }
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string
+    {
+        $basename = pathinfo($sourceFile, PATHINFO_FILENAME);
+        return $basename . '.' . $this->fileExtension();
+    }
 }

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pair\Console\Commands;
 
 use Pair\AgentManager;
+use Pair\Agents\Copilot;
 use Pair\Support\Filesystem;
 use Pair\Support\Project;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -13,4 +13,14 @@ interface Agent
      * Returns the base folder for the agent.
      */
     public function baseFolder(): string;
+
+    /**
+     * Returns the file extension that this agent expects.
+     */
+    public function fileExtension(): string;
+
+    /**
+     * Returns the target filename for a given source file.
+     */
+    public function getTargetFilename(string $sourceFile): string;
 }

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -65,4 +65,14 @@ final readonly class Filesystem
             }
         }
     }
+
+    public static function copyDirectoryFilesForAgent(string $from, string $to, \Pair\Contracts\Agent $agent): void
+    {
+        foreach (glob($from.'/*') ?: [] as $file) {
+            if (is_file($file)) {
+                $targetFilename = $agent->getTargetFilename($file);
+                copy($file, $to.'/'.$targetFilename);
+            }
+        }
+    }
 }

--- a/src/Support/RulesGenerator.php
+++ b/src/Support/RulesGenerator.php
@@ -22,8 +22,10 @@ final readonly class RulesGenerator
 
         mkdir($base, 0755, true);
 
+        $aiDir = $path.'/.ai';
         $defaultsDir = dirname(__DIR__, 2).'/defaults';
+        $sourceDir = is_dir($aiDir) && !empty(glob($aiDir.'/*')) ? $aiDir : $defaultsDir;
 
-        Filesystem::copyDirectoryFiles($defaultsDir, $base);
+        Filesystem::copyDirectoryFilesForAgent($sourceDir, $base, $agent);
     }
 }


### PR DESCRIPTION
- feat(RulesGenerator): generate rules from custom `.ai` config dir if it exists 
- feat(AgentManager): write different file extensions (`.md` vs `.mdc`) based on agent, bc some agents (like Copilot) only supports `.md`
- feat(AgentManager): add GitHub Copilot agent

Resulting dir struct will look like this:
```txt
project-root/
├── .copilot/
│   └── 01_general.md          # GitHub Copilot (Markdown format)
├── .cursor/
│   └── rules/
│       └── 01_general.mdc     # Cursor (MDC format)
├── .windsurfrules/
│   └── 01_general.mdc         # Windsurf (MDC format)
├── .clinerules/
│   └── 01_general.mdc         # Cline (MDC format)
├── .junie/
│   └── 01_general.mdc         # Junie (MDC format)
```